### PR TITLE
Constants easy

### DIFF
--- a/frontend/config.json
+++ b/frontend/config.json
@@ -6,6 +6,7 @@
       "ENV": {
         "name": "dev",
         "apiBase": "http://localhost:8000/api",
+        "imageServer": "http://images.dev-winwins.net",
         "defaultLang": "es",
         "baseLang": "es",
         "availableLangs": ["es", "en"],
@@ -30,6 +31,7 @@
       "ENV": {
         "name": "prod",
         "apiBase": "http://dev-winwins.net/api",
+        "imageServer": "http://images.dev-winwins.net",
         "defaultLang": "es",
         "baseLang": "es",
         "availableLangs": ["es", "en"],

--- a/frontend/src/app/components/sponsor/sponsor.directive.js
+++ b/frontend/src/app/components/sponsor/sponsor.directive.js
@@ -11,7 +11,8 @@
       restrict: 'E',
       templateUrl: 'app/components/sponsor/sponsor.html',
       scope: {
-        items: '='
+        items: '=',
+        url: '@?'
       },
       controller: SponsorController,
       controllerAs: 'vm',
@@ -21,7 +22,9 @@
     return directive;
 
     function SponsorController() {
-      //var vm = this;
+      var vm = this;
+      var defaultUrl = '';
+      vm.url = angular.isDefined(this.url) ? this.url : defaultUrl;
     }
   }
 

--- a/frontend/src/app/components/sponsor/sponsor.html
+++ b/frontend/src/app/components/sponsor/sponsor.html
@@ -7,7 +7,7 @@
     </h1>
     <div layout="row" layout-align="center" layout-wrap class="acme-sponsor-body">
       <div ng-repeat="item in vm.items">
-        <img ng-src="http://images.dev-winwins.net/90x90/smart/{{item.cover_photo}}" alt="{{item.name}}">
+        <img ng-src="{{vm.url}}/90x90/smart/{{item.cover_photo}}" alt="{{item.name}}">
       </div>
     </div>
     <div layout="column" layout-align="center center">

--- a/frontend/src/app/index.run.js
+++ b/frontend/src/app/index.run.js
@@ -22,6 +22,10 @@
       gettextCatalog.debug = true;
       gettextCatalog.debugPrefix = '[Missing]:';
     }
+
+    // On $rootCcope, so we can reference it on templates
+    // without setting on controller
+    $rootScope.imageServer = ENV.imageServer;
   }
 
 })();

--- a/frontend/src/app/main/main.html
+++ b/frontend/src/app/main/main.html
@@ -61,7 +61,7 @@
 
     <acme-miembro items="main.miembros"></acme-miembro>
     <acme-partner items="main.partners"></acme-partner>
-    <acme-sponsor items="main.sponsors"></acme-sponsor>
+    <acme-sponsor items="main.sponsors" url="{{imageServer}}"></acme-sponsor>
 
     <div class="container acme-recientes">
       <h1 class="title">


### PR DESCRIPTION
Para usar las constantes de la manera más simple, las necesarias las ponemos el rootscope para poder utilizarlas globalmente en los templates sin agregarlas en los controladores.
Además agregue como utilizarlas en una directiva, tomando el caso de sponsors.
