### PR TITLE
Container width

### DIFF
--- a/frontend/src/app/components/miembro/miembro.html
+++ b/frontend/src/app/components/miembro/miembro.html
@@ -6,7 +6,7 @@
       <small>{{ 'Personas que crean y participan en acciones de consenso colectivo' | translate }}</small>
     </h1>
     <div layout="row" layout-align="center" layout-wrap>
-      <div ng-repeat="item in vm.items" flex="10">
+      <div ng-repeat="item in vm.items" flex-gt-md="10">
           <div class="acme-miembro-thumb">
             <img ng-src="{{item.imagen}}" alt="{{item.nombre}}">
           </div>

--- a/frontend/src/app/components/miembro/miembro.html
+++ b/frontend/src/app/components/miembro/miembro.html
@@ -6,12 +6,10 @@
       <small>{{ 'Personas que crean y participan en acciones de consenso colectivo' | translate }}</small>
     </h1>
     <div layout="row" layout-align="center" layout-wrap>
-      <div ng-repeat="item in vm.items">
-        <md-card-header>
-          <md-card-avatar>
-            <img class="md-user-avatar" ng-src="{{item.imagen}}" alt="{{item.nombre}}">
-          </md-card-avatar>
-        </md-card-header>
+      <div ng-repeat="item in vm.items" flex="10">
+          <div class="acme-miembro-thumb">
+            <img ng-src="{{item.imagen}}" alt="{{item.nombre}}">
+          </div>
       </div>
     </div>
     <div layout="column" layout-align="center center">

--- a/frontend/src/app/components/miembro/miembro.scss
+++ b/frontend/src/app/components/miembro/miembro.scss
@@ -37,11 +37,17 @@
     min-width: 285px;
     text-transform: initial;
   }
-  md-card-avatar img {
-    border-radius: 50%;
-    margin: 6px;
-    width: 100px;
-    border: 6px solid #D0DBEB;
+  .acme-miembro-thumb {
+    padding: 8px;
+    display: block;
+    img {
+      border-radius: 50%;
+      max-width: 100%;
+      width: 100%;
+      border: 6px solid #D0DBEB;
+      display: block;
+      box-sizing: border-box;
+    }
   }
   .md-green {
     background: #4cae4e;

--- a/frontend/src/app/components/partner/partner.html
+++ b/frontend/src/app/components/partner/partner.html
@@ -7,8 +7,8 @@
       </translate>
     </h1>
 
-    <div layout="row" layout-margin layout-align="center center" layout-wrap>
-      <div ng-repeat="item in vm.items">
+    <div layout="row" layout-align="center center" layout-wrap>
+      <div ng-repeat="item in vm.items" flex="25">
         <img class="md-user-avatar" ng-src="{{item.imagen}}">
       </div>
     </div>

--- a/frontend/src/app/components/partner/partner.html
+++ b/frontend/src/app/components/partner/partner.html
@@ -7,8 +7,8 @@
       </translate>
     </h1>
 
-    <div layout="row" layout-align="center center" layout-wrap>
-      <div ng-repeat="item in vm.items" flex="25">
+    <div layout="row" layout-align="center center" layout-wrap layout-margin>
+      <div ng-repeat="item in vm.items">
         <img class="md-user-avatar" ng-src="{{item.imagen}}">
       </div>
     </div>

--- a/frontend/src/app/components/partner/partner.scss
+++ b/frontend/src/app/components/partner/partner.scss
@@ -20,4 +20,10 @@
       height: 63px;
     }
   }
+  .md-user-avatar {
+    max-width: 100%;
+  }
+  .flex-25 {
+    padding: 8px;
+  }
 }

--- a/frontend/src/app/components/partner/partner.scss
+++ b/frontend/src/app/components/partner/partner.scss
@@ -21,9 +21,6 @@
     }
   }
   .md-user-avatar {
-    max-width: 100%;
-  }
-  .flex-25 {
-    padding: 8px;
+    max-width: 219px;
   }
 }

--- a/frontend/src/app/index.scss
+++ b/frontend/src/app/index.scss
@@ -62,7 +62,7 @@ md-toolbar.md-default-theme {
 }
 
 .container {
-  max-width: 1260px;
+  max-width: 960px;
   margin: 0 auto;
 }
 

--- a/frontend/src/app/main/main.controller.js
+++ b/frontend/src/app/main/main.controller.js
@@ -67,26 +67,6 @@
         img: "assets/images/fondo.jpg",
         title: "Intercambio de novelas policiales",
         user: { logo: "assets/images/logo.png", thumb: "assets/images/thumb.png" }
-      },{
-        id: 11,
-        members: 12,
-        img: "assets/images/fondo.jpg",
-        title: "Intercambio de novelas policiales",
-        user: { logo: "assets/images/logo.png", thumb: "assets/images/thumb.png" }
-      },
-      {
-        id: 11,
-        members: 4,
-        img: "assets/images/fondo.jpg",
-        title: "Intercambio de novelas policiales",
-        user: { logo: "assets/images/logo.png", thumb: "assets/images/thumb.png" }
-      },
-      {
-        id: 11,
-        members: 4,
-        img: "assets/images/fondo.jpg",
-        title: "Intercambio de novelas policiales",
-        user: { logo: "assets/images/logo.png", thumb: "assets/images/thumb.png" }
       }
     ];
 


### PR DESCRIPTION
Cambio del ancho del contenido de la home de 1260 a 960.

Ajuste de miembros y partner al nuevo tamaño.
Según el boceto, en dektop entran 10 miembros por fila.
En tablet y mobile no hay referencia y deje que se adapten solos.

Reducción de items destacados de 9 a 6.
